### PR TITLE
Refactor tests

### DIFF
--- a/tests/test_favicon.py
+++ b/tests/test_favicon.py
@@ -27,7 +27,7 @@ def test_default(m):
     '<link rel="apple-touch-icon-precomposed" href="favicon.ico">',
 ], ids=[
     'icon',
-    'ICON',
+    'ICON (#7)',
     'shortcut icon',
     'apple-touch-icon',
     'apple-touch-icon-precomposed',
@@ -68,6 +68,7 @@ def test_link_sizes_attribute(m, link, size):
 
 @pytest.mark.parametrize('link,url', [
     ('<link rel="icon" href="logo.png">', 'http://mock.com/logo.png'),
+    ('<link rel="icon" href="logo.png\t">', 'http://mock.com/logo.png'),
     ('<link rel="icon" href="/static/logo.png">',
      'http://mock.com/static/logo.png'),
     ('<link rel="icon" href="https://cdn.mock.com/logo.png">',
@@ -78,6 +79,7 @@ def test_link_sizes_attribute(m, link, size):
      'http://mock.com/logo.png?v2'),
 ], ids=[
     'filename',
+    'filename \\t (#5)',
     'relative',
     'https',
     'forward slashes',

--- a/tests/test_favicon.py
+++ b/tests/test_favicon.py
@@ -90,9 +90,10 @@ def test_is_absolute(url, expected):
 @pytest.mark.parametrize('link,size', [
     (s.new_tag('link', href='logo.png', sizes='any'), (0, 0)),
     (s.new_tag('link', href='logo.png', sizes='16x16'), (16, 16)),
+    (s.new_tag('link', href='logo.png', sizes='16x16+'), (16, 16)),
     (s.new_tag('link', href='logo.png', sizes='16x16 32x32'), (32, 32)),
-    (s.new_tag('link', href='logo.png', sizes='16x16 32x32+'), (32, 32)),
-    (s.new_tag('link', href='logo-144x144.png', sizes='any'), (144, 144)),
-])
+    (s.new_tag('link', href='logo.png', sizes='32x32 16x16'), (32, 32)),
+    (s.new_tag('link', href='logo-64x64.png', sizes='any'), (64, 64)),
+], ids=lambda l: str(l['sizes']) if not isinstance(l, tuple) else None)
 def test_dimensions(link, size):
     assert dimensions(link) == size

--- a/tests/test_favicon.py
+++ b/tests/test_favicon.py
@@ -66,6 +66,34 @@ def test_link_sizes_attribute(m, link, size):
     assert icon.width == size[0] and icon.height == size[1]
 
 
+@pytest.mark.parametrize('link,url', [
+    ('<link rel="icon" href="logo.png">', 'http://mock.com/logo.png'),
+    ('<link rel="icon" href="/static/logo.png">',
+     'http://mock.com/static/logo.png'),
+    ('<link rel="icon" href="https://cdn.mock.com/logo.png">',
+     'https://cdn.mock.com/logo.png'),
+    ('<link rel="icon" href="//cdn.mock.com/logo.png">',
+     'http://cdn.mock.com/logo.png'),
+    ('<link rel="icon" href="http://mock.com/logo.png?v2">',
+     'http://mock.com/logo.png?v2'),
+], ids=[
+    'filename',
+    'relative',
+    'https',
+    'forward slashes',
+    'query string',
+])
+def test_link_href_attribute(m, link, url):
+    m.head('http://mock.com/favicon.ico', text='Not Found', status_code=404)
+    m.get('http://mock.com/', text=link)
+
+    icons = favicon.get('http://mock.com/')
+    assert icons
+
+    icon = icons[0]
+    assert icon.url == url
+
+
 @pytest.mark.parametrize('url,expected', [
     ('http://mock.com/favicon.ico', True),
     ('favicon.ico', False),

--- a/tests/test_favicon.py
+++ b/tests/test_favicon.py
@@ -46,7 +46,7 @@ def test_link_rel_attribute(m, link):
     assert icon.format == 'ico'
 
 
-def test_link_sizes(m):
+def test_link_sizes_attribute(m):
     m.head('http://mock.com/favicon.ico', text='Not Found', status_code=404)
     m.get('http://mock.com/',
           text='<link rel="icon" '

--- a/tests/test_favicon.py
+++ b/tests/test_favicon.py
@@ -17,10 +17,22 @@ def test_default(m):
     assert icons[0].url == 'http://mock.com/favicon.ico'
 
 
-def test_link_icon(m):
+@pytest.mark.parametrize('link', [
+    '<link rel="icon" href="favicon.ico">',
+    '<link rel="ICON" href="favicon.ico">',
+    '<link rel="shortcut icon" href="favicon.ico">',
+    '<link rel="apple-touch-icon" href="favicon.ico">',
+    '<link rel="apple-touch-icon-precomposed" href="favicon.ico">',
+], ids=[
+    'icon',
+    'ICON',
+    'shortcut icon',
+    'apple-touch-icon',
+    'apple-touch-icon-precomposed',
+])
+def test_link_rel_attribute(m, link):
     m.head('http://mock.com/favicon.ico', text='Not Found', status_code=404)
-    m.get('http://mock.com/',
-          text='<link rel="icon" type="image/x-icon" href="favicon.ico">')
+    m.get('http://mock.com/', text=link)
 
     icons = favicon.get('http://mock.com/')
     assert icons

--- a/tests/test_favicon.py
+++ b/tests/test_favicon.py
@@ -83,7 +83,7 @@ def test_link_sizes_attribute(m, link, size):
     'relative',
     'https',
     'forward slashes',
-    'query string',
+    'query string (#7)',
 ])
 def test_link_href_attribute(m, link, url):
     m.head('http://mock.com/favicon.ico', text='Not Found', status_code=404)

--- a/tests/test_favicon.py
+++ b/tests/test_favicon.py
@@ -17,7 +17,6 @@ def test_default(m):
 
     icon = icons[0]
     assert icon.url == 'http://mock.com/favicon.ico'
-    assert icon.format == 'ico'
 
 
 @pytest.mark.parametrize('link', [
@@ -40,11 +39,6 @@ def test_link_rel_attribute(m, link):
     icons = favicon.get('http://mock.com/')
     assert icons
 
-    icon = icons[0]
-    assert icon.url == 'http://mock.com/favicon.ico'
-    assert icon.width == 0 and icon.height == 0
-    assert icon.format == 'ico'
-
 
 @pytest.mark.parametrize('link,size', [
     ('<link rel="icon" href="logo.png" sizes="any">', (0, 0)),
@@ -53,6 +47,13 @@ def test_link_rel_attribute(m, link):
     ('<link rel="icon" href="logo.png" sizes="32x32 64x64">', (64, 64)),
     ('<link rel="icon" href="logo.png" sizes="64x64 32x32">', (64, 64)),
     ('<link rel="icon" href="logo-128x128.png" sizes="any">', (128, 128)),
+], ids=[
+    'any',
+    '16x16',
+    '24x24+',
+    '32x32 64x64',
+    '64x64 32x32',
+    'logo-128x128.png',
 ])
 def test_link_sizes_attribute(m, link, size):
     m.head('http://mock.com/favicon.ico', text='Not Found', status_code=404)
@@ -62,8 +63,7 @@ def test_link_sizes_attribute(m, link, size):
     assert icons
 
     icon = icons[0]
-    width, height = size
-    assert icon.width == width and icon.height == height
+    assert icon.width == size[0] and icon.height == size[1]
 
 
 def test_link_apple_touch(m):

--- a/tests/test_favicon.py
+++ b/tests/test_favicon.py
@@ -46,21 +46,24 @@ def test_link_rel_attribute(m, link):
     assert icon.format == 'ico'
 
 
-def test_link_sizes_attribute(m):
+@pytest.mark.parametrize('link,size', [
+    ('<link rel="icon" href="logo.png" sizes="any">', (0, 0)),
+    ('<link rel="icon" href="logo.png" sizes="16x16">', (16, 16)),
+    ('<link rel="icon" href="logo.png" sizes="24x24+">', (24, 24)),
+    ('<link rel="icon" href="logo.png" sizes="32x32 64x64">', (64, 64)),
+    ('<link rel="icon" href="logo.png" sizes="64x64 32x32">', (64, 64)),
+    ('<link rel="icon" href="logo-128x128.png" sizes="any">', (128, 128)),
+])
+def test_link_sizes_attribute(m, link, size):
     m.head('http://mock.com/favicon.ico', text='Not Found', status_code=404)
-    m.get('http://mock.com/',
-          text='<link rel="icon" '
-               'sizes="16x16 32x32" '
-               'type="image/png"'
-               'href="http://mock.com/favicon.png">')
+    m.get('http://mock.com/', text=link)
 
     icons = favicon.get('http://mock.com/')
     assert icons
 
     icon = icons[0]
-    assert icon.url == 'http://mock.com/favicon.png'
-    assert icon.width == 32 and icon.height == 32
-    assert icon.format == 'png'
+    width, height = size
+    assert icon.width == width and icon.height == height
 
 
 def test_link_apple_touch(m):
@@ -86,14 +89,3 @@ def test_link_apple_touch(m):
 def test_is_absolute(url, expected):
     assert is_absolute(url) == expected
 
-
-@pytest.mark.parametrize('link,size', [
-    (s.new_tag('link', href='logo.png', sizes='any'), (0, 0)),
-    (s.new_tag('link', href='logo.png', sizes='16x16'), (16, 16)),
-    (s.new_tag('link', href='logo.png', sizes='16x16+'), (16, 16)),
-    (s.new_tag('link', href='logo.png', sizes='16x16 32x32'), (32, 32)),
-    (s.new_tag('link', href='logo.png', sizes='32x32 16x16'), (32, 32)),
-    (s.new_tag('link', href='logo-64x64.png', sizes='any'), (64, 64)),
-], ids=lambda l: str(l['sizes']) if not isinstance(l, tuple) else None)
-def test_dimensions(link, size):
-    assert dimensions(link) == size

--- a/tests/test_favicon.py
+++ b/tests/test_favicon.py
@@ -2,7 +2,7 @@ import pytest
 from bs4 import BeautifulSoup
 
 import favicon
-from favicon.favicon import dimensions, is_absolute
+from favicon.favicon import is_absolute
 
 s = BeautifulSoup('')
 
@@ -66,21 +66,6 @@ def test_link_sizes_attribute(m, link, size):
     assert icon.width == size[0] and icon.height == size[1]
 
 
-def test_link_apple_touch(m):
-    m.head('http://mock.com/favicon.ico', text='Not Found', status_code=404)
-    m.get('http://mock.com/',
-          text='<link rel="apple-touch-icon" '
-               'href="/static/apple-touch-icon-144x144.png">')
-
-    icons = favicon.get('http://mock.com/')
-    assert icons
-
-    icon = icons[0]
-    assert icon.url == 'http://mock.com/static/apple-touch-icon-144x144.png'
-    assert icon.width == 144 and icon.height == 144
-    assert icon.format == 'png'
-
-
 @pytest.mark.parametrize('url,expected', [
     ('http://mock.com/favicon.ico', True),
     ('favicon.ico', False),
@@ -88,4 +73,3 @@ def test_link_apple_touch(m):
 ])
 def test_is_absolute(url, expected):
     assert is_absolute(url) == expected
-

--- a/tests/test_favicon.py
+++ b/tests/test_favicon.py
@@ -14,7 +14,10 @@ def test_default(m):
 
     icons = favicon.get('http://mock.com/')
     assert icons
-    assert icons[0].url == 'http://mock.com/favicon.ico'
+
+    icon = icons[0]
+    assert icon.url == 'http://mock.com/favicon.ico'
+    assert icon.format == 'ico'
 
 
 @pytest.mark.parametrize('link', [


### PR DESCRIPTION
Break tests into testing each component of parsing a fav icon. Took advantage of using parametrize data sets and applying ids for easier debugging.