### PR TITLE
Support passing request parameters to favicon get

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,17 @@ Download largest icon:
 
    # /tmp/python-favicon.png
 
+`Request library <https://2.python-requests.org/>`_ parameters can be passed to `favicon.get()` as keyword
+arguments:
+
+.. code-block:: python
+
+   import favicon
+
+   user_agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36'
+   headers = {'User-Agent': user_agent}
+   favicon.get('https://www.python.org/', headers=headers, timeout=2)
+
 Requirements
 ============
 

--- a/src/favicon/__init__.py
+++ b/src/favicon/__init__.py
@@ -5,13 +5,10 @@
 """
 from .favicon import Icon, get
 
-__all__ = [
-    'get',
-    'Icon',
-]
+__all__ = ["get", "Icon"]
 
-__title__ = 'favicon'
-__version__ = '0.6.0'
-__author__ = 'Scott Werner'
-__license__ = 'MIT'
-__copyright__ = 'Copyright 2018 Scott Werner'
+__title__ = "favicon"
+__version__ = "0.6.0"
+__author__ = "Scott Werner"
+__license__ = "MIT"
+__copyright__ = "Copyright 2018 Scott Werner"

--- a/src/favicon/favicon.py
+++ b/src/favicon/favicon.py
@@ -19,8 +19,8 @@ __all__ = ['get', 'Icon']
 
 HEADERS = {
     'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) '
-                  'AppleWebKit/537.36 (KHTML, like Gecko) '
-                  'Chrome/33.0.1750.152 Safari/537.36',
+    'AppleWebKit/537.36 (KHTML, like Gecko) '
+    'Chrome/33.0.1750.152 Safari/537.36'
 }
 
 LINK_RELS = [
@@ -30,14 +30,9 @@ LINK_RELS = [
     'apple-touch-icon-precomposed',
 ]
 
-META_NAMES = [
-    'msapplication-TileImage',
-    'og:image',
-]
+META_NAMES = ['msapplication-TileImage', 'og:image']
 
-SIZE_RE = re.compile(
-    r'(?P<width>\d{2,4})x(?P<height>\d{2,4})',
-    flags=re.IGNORECASE)
+SIZE_RE = re.compile(r'(?P<width>\d{2,4})x(?P<height>\d{2,4})', flags=re.IGNORECASE)
 
 Icon = namedtuple('Icon', ['url', 'width', 'height', 'format'])
 
@@ -114,10 +109,9 @@ def tags(url, html):
 
     link_tags = set()
     for rel in LINK_RELS:
-        for link_tag in soup.find_all('link', attrs={
-            'rel': lambda r: r and r.lower() == rel,
-            'href': True
-        }):
+        for link_tag in soup.find_all(
+            'link', attrs={'rel': lambda r: r and r.lower() == rel, 'href': True}
+        ):
             link_tags.add(link_tag)
 
     meta_tags = set()

--- a/src/favicon/favicon.py
+++ b/src/favicon/favicon.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """favicon
-:copyright: (c) 2018 by Scott Werner.
+:copyright: (c) 2019 by Scott Werner.
 :license: MIT, see LICENSE for more details.
 """
 import os
@@ -42,27 +42,29 @@ SIZE_RE = re.compile(
 Icon = namedtuple('Icon', ['url', 'width', 'height', 'format'])
 
 
-def get(url, headers=None):
+def get(url, *args, **request_kwargs):
     """Get all fav icons for a url.
 
     :param url: Homepage.
     :type url: str
 
-    :param headers: Request headers.
-    :type headers: dict or None
+    :param request_kwargs: Request headers argument.
+    :type request_kwargs: Dict
 
     :return: List of fav icons found sorted by icon dimension.
     :rtype: list[:class:`Icon`]
     """
-    if not headers:
-        headers = HEADERS
+    if args:  # c
+        request_kwargs.setdefault('headers', args[0])
+    request_kwargs.setdefault('headers', HEADERS)
+    request_kwargs.setdefault('allow_redirects', True)
 
-    response = requests.get(url, headers=headers, allow_redirects=True)
+    response = requests.get(url, **request_kwargs)
     response.raise_for_status()
 
     icons = set()
 
-    default_icon = default(response.url, headers)
+    default_icon = default(response.url, **request_kwargs)
     if default_icon:
         icons.add(default_icon)
 
@@ -73,20 +75,20 @@ def get(url, headers=None):
     return sorted(icons, key=lambda i: i.width + i.height, reverse=True)
 
 
-def default(url, headers):
+def default(url, **request_kwargs):
     """Get icon using default filename favicon.ico.
 
     :param url: Url for site.
     :type url: str
 
-    :param headers: Request headers.
-    :type headers: dict
+    :param request_kwargs: Request headers argument.
+    :type request_kwargs: Dict
 
     :return: Icon or None.
     :rtype: :class:`Icon` or None
     """
     favicon_url = urljoin(url, 'favicon.ico')
-    response = requests.head(favicon_url, headers=headers, allow_redirects=True)
+    response = requests.head(favicon_url, **request_kwargs)
     if response.status_code == 200:
         return Icon(response.url, 0, 0, 'ico')
 

--- a/tests/test_favicon.py
+++ b/tests/test_favicon.py
@@ -120,6 +120,20 @@ def test_invalid_meta_tag(m):
     assert not icons
 
 
+def test_request_kwargs(m):
+    headers = {'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0'}
+    m.get('http://mock.com/', request_headers=headers, text='body')
+
+    # raises requests_mock.exceptions.NoMockAddress if headers do not match
+    # https://requests-mock.readthedocs.io/en/latest/matching.html#request-headers
+    with pytest.warns(None):
+        favicon.get('http://mock.com/', headers=headers)
+
+    # Test deprecated header argument
+    with pytest.warns(None):
+        favicon.get('http://mock.com/', headers=headers)
+
+
 @pytest.mark.parametrize('url,expected', [
     ('http://mock.com/favicon.ico', True),
     ('favicon.ico', False),

--- a/tests/test_favicon.py
+++ b/tests/test_favicon.py
@@ -20,19 +20,23 @@ def test_default(m):
     assert icon.url == 'http://mock.com/favicon.ico'
 
 
-@pytest.mark.parametrize('link', [
-    '<link rel="icon" href="favicon.ico">',
-    '<link rel="ICON" href="favicon.ico">',
-    '<link rel="shortcut icon" href="favicon.ico">',
-    '<link rel="apple-touch-icon" href="favicon.ico">',
-    '<link rel="apple-touch-icon-precomposed" href="favicon.ico">',
-], ids=[
-    'icon',
-    'ICON (#7)',
-    'shortcut icon',
-    'apple-touch-icon',
-    'apple-touch-icon-precomposed',
-])
+@pytest.mark.parametrize(
+    'link',
+    [
+        '<link rel="icon" href="favicon.ico">',
+        '<link rel="ICON" href="favicon.ico">',
+        '<link rel="shortcut icon" href="favicon.ico">',
+        '<link rel="apple-touch-icon" href="favicon.ico">',
+        '<link rel="apple-touch-icon-precomposed" href="favicon.ico">',
+    ],
+    ids=[
+        'icon',
+        'ICON (#7)',
+        'shortcut icon',
+        'apple-touch-icon',
+        'apple-touch-icon-precomposed',
+    ],
+)
 def test_link_tag(m, link):
     m.get('http://mock.com/', text=link)
 
@@ -40,23 +44,27 @@ def test_link_tag(m, link):
     assert icons
 
 
-@pytest.mark.parametrize('link,size', [
-    ('<link rel="icon" href="logo.png" sizes="any">', (0, 0)),
-    ('<link rel="icon" href="logo.png" sizes="16x16">', (16, 16)),
-    ('<link rel="icon" href="logo.png" sizes="24x24+">', (24, 24)),
-    ('<link rel="icon" href="logo.png" sizes="32x32 64x64">', (64, 64)),
-    ('<link rel="icon" href="logo.png" sizes="64x64 32x32">', (64, 64)),
-    ('<link rel="icon" href="logo-128x128.png" sizes="any">', (128, 128)),
-    (u'<link rel="icon" href="logo.png" sizes="16×16">', (16, 16)),
-], ids=[
-    'any',
-    '16x16',
-    '24x24+',
-    '32x32 64x64',
-    '64x64 32x32',
-    'logo-128x128.png',
-    'new york times (#9)',
-])
+@pytest.mark.parametrize(
+    'link,size',
+    [
+        ('<link rel="icon" href="logo.png" sizes="any">', (0, 0)),
+        ('<link rel="icon" href="logo.png" sizes="16x16">', (16, 16)),
+        ('<link rel="icon" href="logo.png" sizes="24x24+">', (24, 24)),
+        ('<link rel="icon" href="logo.png" sizes="32x32 64x64">', (64, 64)),
+        ('<link rel="icon" href="logo.png" sizes="64x64 32x32">', (64, 64)),
+        ('<link rel="icon" href="logo-128x128.png" sizes="any">', (128, 128)),
+        (u'<link rel="icon" href="logo.png" sizes="16×16">', (16, 16)),
+    ],
+    ids=[
+        'any',
+        '16x16',
+        '24x24+',
+        '32x32 64x64',
+        '64x64 32x32',
+        'logo-128x128.png',
+        'new york times (#9)',
+    ],
+)
 def test_link_tag_sizes_attribute(m, link, size):
     m.get('http://mock.com/', text=link)
 
@@ -67,25 +75,37 @@ def test_link_tag_sizes_attribute(m, link, size):
     assert icon.width == size[0] and icon.height == size[1]
 
 
-@pytest.mark.parametrize('link,url', [
-    ('<link rel="icon" href="logo.png">', 'http://mock.com/logo.png'),
-    ('<link rel="icon" href="logo.png\t">', 'http://mock.com/logo.png'),
-    ('<link rel="icon" href="/static/logo.png">',
-     'http://mock.com/static/logo.png'),
-    ('<link rel="icon" href="https://cdn.mock.com/logo.png">',
-     'https://cdn.mock.com/logo.png'),
-    ('<link rel="icon" href="//cdn.mock.com/logo.png">',
-     'http://cdn.mock.com/logo.png'),
-    ('<link rel="icon" href="http://mock.com/logo.png?v2">',
-     'http://mock.com/logo.png?v2'),
-], ids=[
-    'filename',
-    'filename \\t (#5)',
-    'relative',
-    'https',
-    'forward slashes',
-    'query string (#7)',
-])
+@pytest.mark.parametrize(
+    'link,url',
+    [
+        ('<link rel="icon" href="logo.png">', 'http://mock.com/logo.png'),
+        ('<link rel="icon" href="logo.png\t">', 'http://mock.com/logo.png'),
+        (
+            '<link rel="icon" href="/static/logo.png">',
+            'http://mock.com/static/logo.png',
+        ),
+        (
+            '<link rel="icon" href="https://cdn.mock.com/logo.png">',
+            'https://cdn.mock.com/logo.png',
+        ),
+        (
+            '<link rel="icon" href="//cdn.mock.com/logo.png">',
+            'http://cdn.mock.com/logo.png',
+        ),
+        (
+            '<link rel="icon" href="http://mock.com/logo.png?v2">',
+            'http://mock.com/logo.png?v2',
+        ),
+    ],
+    ids=[
+        'filename',
+        'filename \\t (#5)',
+        'relative',
+        'https',
+        'forward slashes',
+        'query string (#7)',
+    ],
+)
 def test_link_tag_href_attribute(m, link, url):
     m.get('http://mock.com/', text=link)
 
@@ -96,15 +116,15 @@ def test_link_tag_href_attribute(m, link, url):
     assert icon.url == url
 
 
-@pytest.mark.parametrize('meta_tag', [
-    '<meta name="msapplication-TileImage" content="favicon.ico">',
-    '<meta name="msapplication-tileimage" content="favicon.ico">',
-    '<meta property="og:image" content="favicon.png">',
-], ids=[
-    'msapplication-TileImage',
-    'msapplication-tileimage',
-    'og:image',
-])
+@pytest.mark.parametrize(
+    'meta_tag',
+    [
+        '<meta name="msapplication-TileImage" content="favicon.ico">',
+        '<meta name="msapplication-tileimage" content="favicon.ico">',
+        '<meta property="og:image" content="favicon.png">',
+    ],
+    ids=['msapplication-TileImage', 'msapplication-tileimage', 'og:image'],
+)
 def test_meta_tag(m, meta_tag):
     m.get('http://mock.com/', text=meta_tag)
 
@@ -113,15 +133,19 @@ def test_meta_tag(m, meta_tag):
 
 
 def test_invalid_meta_tag(m):
-    m.get('http://mock.com/',
-          text='<meta content="en-US" data-rh="true" itemprop="inLanguage"/>')
+    m.get(
+        'http://mock.com/',
+        text='<meta content="en-US" data-rh="true" itemprop="inLanguage"/>',
+    )
 
     icons = favicon.get('http://mock.com/')
     assert not icons
 
 
 def test_request_kwargs(m):
-    headers = {'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0'}
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0'
+    }
     m.get('http://mock.com/', request_headers=headers, text='body')
 
     # raises requests_mock.exceptions.NoMockAddress if headers do not match
@@ -134,10 +158,13 @@ def test_request_kwargs(m):
         favicon.get('http://mock.com/', headers=headers)
 
 
-@pytest.mark.parametrize('url,expected', [
-    ('http://mock.com/favicon.ico', True),
-    ('favicon.ico', False),
-    ('/favicon.ico', False),
-])
+@pytest.mark.parametrize(
+    'url,expected',
+    [
+        ('http://mock.com/favicon.ico', True),
+        ('favicon.ico', False),
+        ('/favicon.ico', False),
+    ],
+)
 def test_is_absolute_helper(url, expected):
     assert is_absolute(url) == expected


### PR DESCRIPTION
Fixes #21: Deprecate `headers` argument and replace with `request_kwargs` keyword arguments.