### PR TITLE
Do not check the HTTP response status code.

### DIFF
--- a/src/favicon/favicon.py
+++ b/src/favicon/favicon.py
@@ -63,7 +63,6 @@ def get(url, *args, **request_kwargs):
     request_kwargs.setdefault('allow_redirects', True)
 
     response = requests.get(url, **request_kwargs)
-    response.raise_for_status()
 
     icons = set()
 


### PR DESCRIPTION
Any non-successful response may still contain body content and
potentially a usable favicon link. In particular, 401 Unauthorized
redirects to a login page.