### PR TITLE
Handle tags with uppercased 'sizes' attr

### DIFF
--- a/src/favicon/favicon.py
+++ b/src/favicon/favicon.py
@@ -182,7 +182,7 @@ def dimensions(tag):
     if sizes and sizes != 'any':
         size = sizes.split(' ')  # '16x16 32x32 64x64'
         size.sort(reverse=True)
-        width, height = re.split(r'[x\xd7]', size[0])
+        width, height = re.split(r'[x\xd7]', size[0], flags=re.I)
     else:
         filename = tag.get('href') or tag.get('content')
         size = SIZE_RE.search(filename)


### PR DESCRIPTION
Some web sources contains tags like:
```xml
<link data-react-helmet="true" href="/public/favicons/color-1.ico" rel="shortcut icon" sizes="192X192" type="image/x-icon"/>
```
In order to handle them correctly it's necessary to ignore the 'sizes' attribute case while resolving the dimensions